### PR TITLE
Add GitHub Action for wiki deployment CI/CD

### DIFF
--- a/.github/workflows/build_wiki.yaml
+++ b/.github/workflows/build_wiki.yaml
@@ -1,0 +1,62 @@
+name: Build docs site
+on:
+  workflow_dispatch: # manual trigger
+  push:
+    branches:
+      - master
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+      # Give the default GITHUB_TOKEN write permission to deploy GitHub Pages
+      pages: write
+      id-token: write
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: Pull & update theme files
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+
+      - name: Build site
+        run: ./bin/hugo --destination=docs
+
+      - name: Build deploying branch
+        run: |
+          find . -mindepth 1 -not -name '_docs' -not -name '.git' -not -path './.git/*' -not -path './docs*' -exec rm -rf {} +
+          mv docs/* .
+          rmdir docs
+      
+      - name: Commit files
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Build site
+          branch: gh-pages
+          create_branch: true
+          push_options: '--force'
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: github-pages
+          path: .
+      
+      - name: Deploy artifact to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages


### PR DESCRIPTION
Use GitHub Actions for automated CI/CD pipeline to build and deploy the wiki site. The original repo uses Travis CI, but now GitHub provides Actions that can run CI/CD pipeline natively in GitHub.

Created new YAML workflow file. The deployed site will be available at https://WIF3005-software-maintenance-deans-cms.github.io/deans-wiki .

Name: Koo Song Le
Matric: S2116593
@suhadaudd11